### PR TITLE
global-cashinsight

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -803,6 +803,7 @@ The `Version` relates to the `Status` column. If `Status` is Vulnerable, Version
 | GFI Software | Kerio Connect | | Vulnerable | | [source](https://forums.gfi.com/index.php?t=msg&th=39096&start=0&)|
 | GitHub | Github Enterprise Server | 3.3.1, 3.2.6, 3.1.14, 3.0.22 | Fix | | [source](https://github.blog/2021-12-13-githubs-response-to-log4j-vulnerability-cve-2021-44228/) |
 | GitLab | GitLab || Not vuln | | [source](https://forum.gitlab.com/t/cve-2021-4428/62763/8)|
+| Glory | CashInsight | at least: 3.3.21, 4.7.5a | Unknown | Awaiting confirmation from vendor. Data from personal research | |
 | GoAnywhere| Agents| Unknown| Workaround | | [source](https://www.goanywhere.com/cve-2021-44228-goanywhere-mitigation-steps)|
 | GoAnywhere| Gateway| Unknown| Workaround | | [source](https://www.goanywhere.com/cve-2021-44228-goanywhere-mitigation-steps)|
 | GoAnywhere| MFT| Unknown| Workaround | | [source](https://www.goanywhere.com/cve-2021-44228-goanywhere-mitigation-steps)|


### PR DESCRIPTION
Found log4j 2.13.1 in recent CashInsights release v4.7.5a installer.
Reached out to vendor with service request for official stance on vulnerability. 
Product Page: https://www.glory-global.com/en-gb/products-and-services/software/teller-connectivity/cashinsight-assure/




Thank you for your contribution! Some pointers to get it merged quickly:

For contributions in `software/`:

  - Status: please select a value from the status table at the top
  - Version: Status Vulnerable / Workaround? -> List vulnerable versions.
             Status Fix?                     -> List fixed versions.
  - Links: make sure you link to a public statement by the developer.
    Alternatively, include and link a file in the `software/vendor-statements/`
    directory
  - Please mind the sorting
  - Please put vendor/product name in PR title (instead of "Update README.md")
